### PR TITLE
feat(backend): setup initial Spring Boot structure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/nbactions.xml
+++ b/nbactions.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<actions>
+    <action>
+        <actionName>run</actionName>
+        <packagings>
+            <packaging>jar</packaging>
+        </packagings>
+        <goals>
+            <goal>spring-boot:run</goal>
+        </goals>
+        <properties>
+            <run.jvmArguments>-noverify -XX:TieredStopAtLevel=1 </run.jvmArguments>
+            <run.mainClass>com.franciscogua.markdowntopdf.Markdown-to-pdfApplication</run.mainClass>
+            <Env.SPRING_OUTPUT_ANSI_ENABLED>always</Env.SPRING_OUTPUT_ANSI_ENABLED>
+        </properties>
+    </action>
+    <action>
+        <actionName>debug</actionName>
+        <packagings>
+            <packaging>jar</packaging>
+        </packagings>
+        <goals>
+            <goal>spring-boot:run</goal>
+        </goals>
+        <properties>
+            <run.jvmArguments>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address} -noverify -XX:TieredStopAtLevel=1 </run.jvmArguments>
+            <run.mainClass>com.franciscogua.markdowntopdf.Markdown-to-pdfApplication</run.mainClass>
+            <Env.SPRING_OUTPUT_ANSI_ENABLED>always</Env.SPRING_OUTPUT_ANSI_ENABLED>
+            <jpda.listen>true</jpda.listen>
+        </properties>
+    </action>
+    <action>
+        <actionName>profile</actionName>
+        <packagings>
+            <packaging>jar</packaging>
+        </packagings>
+        <goals>
+            <goal>process-classes</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
+        </goals>
+        <properties>
+            <exec.args>-classpath %classpath com.franciscogua.markdowntopdf.Markdown-to-pdfApplication</exec.args>
+            <exec.executable>java</exec.executable>
+        </properties>
+    </action>
+</actions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.5.5</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.franciscogua</groupId>
+	<artifactId>markdown-to-pdf</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>markdown-to-pdf</name>
+	<description>Conversor de Markdown a PDF con previsualización en tiempo real.</description>
+	<properties>
+		<java.version>21</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/main/java/com/franciscogua/markdowntopdf/MarkdownToPdfApplication.java
+++ b/src/main/java/com/franciscogua/markdowntopdf/MarkdownToPdfApplication.java
@@ -1,0 +1,13 @@
+package com.franciscogua.markdowntopdf;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MarkdownToPdfApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(MarkdownToPdfApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/franciscogua/markdowntopdf/controlller/PdfController.java
+++ b/src/main/java/com/franciscogua/markdowntopdf/controlller/PdfController.java
@@ -1,0 +1,26 @@
+package com.franciscogua.markdowntopdf.controlller;
+
+import com.franciscogua.markdowntopdf.dto.MarkdownRequestDto;
+import com.franciscogua.markdowntopdf.service.PdfService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class PdfController {
+    private final PdfService pdfService;
+    
+    public PdfController(PdfService pdfService) {
+        this.pdfService = pdfService;
+    }
+    
+    @PostMapping("/generate-pdf")
+    public ResponseEntity<Void> generatePdf(@RequestBody MarkdownRequestDto requestDto) {
+       
+        pdfService.generatePdf(requestDto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/franciscogua/markdowntopdf/dto/MarkdownRequestDto.java
+++ b/src/main/java/com/franciscogua/markdowntopdf/dto/MarkdownRequestDto.java
@@ -1,0 +1,9 @@
+package com.franciscogua.markdowntopdf.dto;
+
+public class MarkdownRequestDto {
+    public String markdown;
+    
+    public void setMarkdown(String markdown) {
+        this.markdown = markdown;
+    }
+}

--- a/src/main/java/com/franciscogua/markdowntopdf/service/PdfService.java
+++ b/src/main/java/com/franciscogua/markdowntopdf/service/PdfService.java
@@ -1,0 +1,11 @@
+package com.franciscogua.markdowntopdf.service;
+
+import com.franciscogua.markdowntopdf.dto.MarkdownRequestDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PdfService {
+    public void generatePdf(MarkdownRequestDto requestDto) {
+        
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=markdown-to-pdf

--- a/src/test/java/com/franciscogua/markdowntopdf/MarkdownToPdfApplicationTests.java
+++ b/src/test/java/com/franciscogua/markdowntopdf/MarkdownToPdfApplicationTests.java
@@ -1,0 +1,13 @@
+package com.franciscogua.markdowntopdf;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MarkdownToPdfApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
### **Resumen**

Este Pull Request introduce la estructura base del backend para la aplicación de conversión de Markdown a PDF. El objetivo de esta fase es establecer un proyecto Spring Boot funcional con los componentes esenciales (controlador, servicio, DTO) y un endpoint inicial que confirme que el servidor responde correctamente.

#### **Cambios Implementados**

*   Se generó un proyecto Spring Boot 3 con Maven y Java 21.
*   Se añadió la dependencia `Spring Web` para habilitar la funcionalidad de API REST.
*   Se creó una estructura de paquetes (`controller`, `service`, `dto`) para organizar el código.
*   Se implementó un `PdfController` que expone el endpoint `POST /api/generate-pdf`.
*   Se definió el DTO `MarkdownRequestDto` para modelar el cuerpo de la petición.
*   Se creó una clase `PdfService` con un método vacío, preparada para la lógica de negocio futura.
*   El endpoint actual devuelve una respuesta `200 OK` para indicar que la aplicación está operativa, sin procesar todavía los datos.