### PR TITLE
feat(backend): implement html to pdf conversion logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+                <dependency>
+                    <groupId>com.github.librepdf</groupId>
+                    <artifactId>openpdf</artifactId>
+                    <version>1.3.30</version>
+                </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/franciscogua/markdowntopdf/controlller/PdfController.java
+++ b/src/main/java/com/franciscogua/markdowntopdf/controlller/PdfController.java
@@ -1,7 +1,9 @@
 package com.franciscogua.markdowntopdf.controlller;
 
-import com.franciscogua.markdowntopdf.dto.MarkdownRequestDto;
+import com.franciscogua.markdowntopdf.dto.PdfRequestDto;
 import com.franciscogua.markdowntopdf.service.PdfService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,16 +13,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 public class PdfController {
+
     private final PdfService pdfService;
-    
+
     public PdfController(PdfService pdfService) {
         this.pdfService = pdfService;
     }
-    
+
     @PostMapping("/generate-pdf")
-    public ResponseEntity<Void> generatePdf(@RequestBody MarkdownRequestDto requestDto) {
-       
-        pdfService.generatePdf(requestDto);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<byte[]> generatePdf(@RequestBody PdfRequestDto requestDto) {
+        try {
+            byte[] pdfBytes = pdfService.generatePdfFromHtml(requestDto.getHtmlContent());
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_PDF);
+            headers.setContentDispositionFormData("attachment", "documento.pdf");
+
+            return ResponseEntity.ok()
+                    .headers(headers)
+                    .body(pdfBytes);
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
     }
 }

--- a/src/main/java/com/franciscogua/markdowntopdf/dto/MarkdownRequestDto.java
+++ b/src/main/java/com/franciscogua/markdowntopdf/dto/MarkdownRequestDto.java
@@ -1,9 +1,0 @@
-package com.franciscogua.markdowntopdf.dto;
-
-public class MarkdownRequestDto {
-    public String markdown;
-    
-    public void setMarkdown(String markdown) {
-        this.markdown = markdown;
-    }
-}

--- a/src/main/java/com/franciscogua/markdowntopdf/dto/PdfRequestDto.java
+++ b/src/main/java/com/franciscogua/markdowntopdf/dto/PdfRequestDto.java
@@ -1,0 +1,13 @@
+package com.franciscogua.markdowntopdf.dto;
+
+public class PdfRequestDto {
+    public String htmlContent;
+    
+    public String getHtmlContent() {
+        return htmlContent;
+    }
+
+    public void setHtmlContent(String htmlContent) {
+        this.htmlContent = htmlContent;
+    }
+}

--- a/src/main/java/com/franciscogua/markdowntopdf/service/PdfService.java
+++ b/src/main/java/com/franciscogua/markdowntopdf/service/PdfService.java
@@ -1,11 +1,29 @@
 package com.franciscogua.markdowntopdf.service;
 
-import com.franciscogua.markdowntopdf.dto.MarkdownRequestDto;
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.html.simpleparser.HTMLWorker;
+import com.lowagie.text.pdf.PdfWriter;
 import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringReader;
 
 @Service
 public class PdfService {
-    public void generatePdf(MarkdownRequestDto requestDto) {
+    public byte[] generatePdfFromHtml(String htmlContent) throws DocumentException, IOException {
+        Document document = new Document();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PdfWriter.getInstance(document, baos);
         
+        document.open();
+        
+        HTMLWorker htmlWorker = new HTMLWorker(document);
+        htmlWorker.parse(new StringReader(htmlContent));
+        
+        document.close();
+        
+        return baos.toByteArray();
     }
 }


### PR DESCRIPTION
### **Resumen**

Este Pull Request implementa la funcionalidad principal del backend: la conversión de una cadena de texto HTML a un documento PDF. El servicio ahora puede procesar el contenido y devolver un archivo PDF binario, listo para ser descargado por el cliente.

#### **Cambios Implementados**

*   Se añadió la dependencia `com.github.librepdf:openpdf` al `pom.xml` para manejar la generación de PDF.
*   Se refactorizó el DTO de `MarkdownRequestDto` a `PdfRequestDto`, cambiando el campo esperado de Markdown a `htmlContent` para que coincida con lo que el frontend puede proveer eficientemente.
*   Se actualizó el `PdfController` para que devuelva una `ResponseEntity<byte[]>`.
*   Se configuraron las cabeceras HTTP `Content-Type` y `Content-Disposition` en el controlador para asegurar que los navegadores interpreten la respuesta como una descarga de archivo PDF.
*   Se implementó la lógica de conversión en `PdfService` utilizando `Document`, `PdfWriter` y `HTMLWorker` de OpenPDF para transformar el HTML en un `byte[]`.
*   Se añadió manejo de excepciones básico en el controlador para devolver un error 500 si la generación del PDF falla.