### PR TITLE
feat: integrate frontend and backend for pdf generation

### DIFF
--- a/frontend/src/components/MarkdownEditor.css
+++ b/frontend/src/components/MarkdownEditor.css
@@ -72,3 +72,10 @@
   width: 100%;
   line-height: 1.6;
 }
+
+.export-button:disabled {
+  background-color: #5a6268;
+  border-color: #5a6268;
+  cursor: not-allowed;
+  opacity: 0.65;
+}

--- a/frontend/src/components/MarkdownEditor.jsx
+++ b/frontend/src/components/MarkdownEditor.jsx
@@ -3,37 +3,183 @@ import { marked } from "marked";
 import DOMPurify from "dompurify";
 import "./MarkdownEditor.css";
 
+const convertToXhtml = (html) => {
+  return html
+    .replace(/<hr>/g, "<hr />")
+    .replace(/<br>/g, "<br />")
+    .replace(/<img>/g, "<img />");
+};
+
 function MarkdownEditor() {
-  const [markdown, setMarkdown] = useState(`# ¡Hola, mundo! 
-  ## Esto es una previsualización en tiempo real
-  - Escribe Markdown en el panel de la izquierda.
-  - Visualiza el HTML renderizado a la derecha.
-  \`\`\`javascript
-    function saludo() {
-      console.log("¡Hola desde el bloque de código!");
-    }
-  \`\`\``);
+  const [markdown, setMarkdown] = useState(`# ¡Bienvenido a tu Editor Markdown!
+
+## Comienza a escribir y mira la magia en tiempo real
+
+Esta aplicación te permite convertir tus notas de **Markdown** a un archivo **PDF** con un estilo profesional.
+
+---
+
+### ¿Listo para Probar?
+
+1.  Modifica este texto o pega tu propio Markdown.
+2.  Haz clic en el botón **"Exportar a PDF"**.
+3.  ¡Disfruta de tu documento!`);
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleMarkdownChange = (event) => {
     setMarkdown(event.target.value);
   };
 
-  const getSanitizedHtml = (markdownText) => {
+  const getSanitizedHtmlForPreview = (markdownText) => {
     const rawHtml = marked.parse(markdownText);
     return DOMPurify.sanitize(rawHtml);
+  };
+
+  const handleExportPdf = async () => {
+    setIsLoading(true);
+
+    const rawHtml = marked.parse(markdown);
+    const baseHtml = convertToXhtml(rawHtml);
+
+    const styles = `
+      <style>
+        @page {
+          margin: 1.5cm;
+        }
+        body {
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+          font-size: 11pt;
+          line-height: 1.6;
+          color: #24292e;
+        }
+        h1, h2, h3, h4, h5, h6 {
+          font-weight: 600;
+          line-height: 1.25;
+          margin-top: 24px;
+          margin-bottom: 16px;
+          border-bottom: 1px solid #eaecef;
+          padding-bottom: 0.3em;
+        }
+        h1 { font-size: 2em; }
+        h2 { font-size: 1.5em; }
+        h3 { font-size: 1.25em; }
+        code {
+          background-color: #f6f8fa;
+          padding: 0.2em 0.4em;
+          margin: 0;
+          font-size: 85%;
+          border-radius: 6px;
+          font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+        }
+        pre {
+          background-color: #f6f8fa;
+          padding: 16px;
+          overflow: auto;
+          line-height: 1.45;
+          border-radius: 6px;
+        }
+        pre code {
+          padding: 0;
+          margin: 0;
+          font-size: 100%;
+          background-color: transparent;
+        }
+        blockquote {
+          color: #6a737d;
+          border-left: 0.25em solid #dfe2e5;
+          padding: 0 1em;
+          margin-left: 0;
+        }
+        ul, ol {
+          padding-left: 2em;
+        }
+        table {
+          border-collapse: collapse;
+          width: 100%;
+          margin-top: 1em;
+          margin-bottom: 1em;
+        }
+        th, td {
+          border: 1px solid #dfe2e5;
+          padding: 8px 13px;
+        }
+        th {
+          font-weight: 600;
+        }
+        a {
+          color: #0366d6;
+          text-decoration: none;
+        }
+        a:hover {
+          text-decoration: underline;
+        }
+      </style>
+    `;
+
+    const htmlContent = `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="UTF-8" />
+          ${styles}
+        </head>
+        <body>
+          ${baseHtml}
+        </body>
+      </html>
+    `;
+
+    try {
+      const response = await fetch("http://localhost:8080/api/generate-pdf", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ htmlContent }),
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `Error del servidor: ${response.status} ${response.statusText}`
+        );
+      }
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", "documento.pdf");
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("Error al generar el PDF:", error);
+      alert(
+        "No se pudo generar el PDF. Asegúrate de que el backend esté funcionando y revisa la consola del navegador para más detalles."
+      );
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
     <div className="app-container">
       <header className="app-header">
         <h1>Markdown to PDF Converter</h1>
-        <button className="export-button">Exportar a PDF</button>
+        <button
+          className="export-button"
+          onClick={handleExportPdf}
+          disabled={isLoading}
+        >
+          {isLoading ? "Generando..." : "Exportar a PDF"}
+        </button>
       </header>
       <main className="editor-layout">
         <div className="editor-pane">
           <textarea
             className="editor-textarea"
-            placeholder="Escribe tu markdown aquí..."
+            placeholder="Escribe tu Markdown aquí..."
             value={markdown}
             onChange={handleMarkdownChange}
           ></textarea>
@@ -41,7 +187,9 @@ function MarkdownEditor() {
         <div className="preview-pane">
           <div
             className="preview-content"
-            dangerouslySetInnerHTML={{ __html: getSanitizedHtml(markdown) }}
+            dangerouslySetInnerHTML={{
+              __html: getSanitizedHtmlForPreview(markdown),
+            }}
           ></div>
         </div>
       </main>

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,9 @@
 			<scope>test</scope>
 		</dependency>
                 <dependency>
-                    <groupId>com.github.librepdf</groupId>
-                    <artifactId>openpdf</artifactId>
-                    <version>1.3.30</version>
+                    <groupId>com.openhtmltopdf</groupId>
+                    <artifactId>openhtmltopdf-pdfbox</artifactId>
+                    <version>1.0.10</version>
                 </dependency>
 	</dependencies>
 

--- a/src/main/java/com/franciscogua/markdowntopdf/controlller/PdfController.java
+++ b/src/main/java/com/franciscogua/markdowntopdf/controlller/PdfController.java
@@ -5,6 +5,7 @@ import com.franciscogua.markdowntopdf.service.PdfService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api")
+@CrossOrigin(origins = "http://localhost:5173")
 public class PdfController {
 
     private final PdfService pdfService;
@@ -32,6 +34,7 @@ public class PdfController {
                     .headers(headers)
                     .body(pdfBytes);
         } catch (Exception e) {
+            e.printStackTrace();
             return ResponseEntity.internalServerError().build();
         }
     }

--- a/src/main/java/com/franciscogua/markdowntopdf/service/PdfService.java
+++ b/src/main/java/com/franciscogua/markdowntopdf/service/PdfService.java
@@ -1,28 +1,22 @@
 package com.franciscogua.markdowntopdf.service;
 
-import com.lowagie.text.Document;
-import com.lowagie.text.DocumentException;
-import com.lowagie.text.html.simpleparser.HTMLWorker;
-import com.lowagie.text.pdf.PdfWriter;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.StringReader;
 
 @Service
 public class PdfService {
-    public byte[] generatePdfFromHtml(String htmlContent) throws DocumentException, IOException {
-        Document document = new Document();
+
+    public byte[] generatePdfFromHtml(String htmlContent) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PdfWriter.getInstance(document, baos);
         
-        document.open();
-        
-        HTMLWorker htmlWorker = new HTMLWorker(document);
-        htmlWorker.parse(new StringReader(htmlContent));
-        
-        document.close();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.useFastMode();
+        builder.withHtmlContent(htmlContent, null);
+        builder.toStream(baos);
+        builder.run();
         
         return baos.toByteArray();
     }


### PR DESCRIPTION
### **Resumen**

Este Pull Request finaliza la integración completa entre el frontend de React y el backend de Spring Boot. Implementa la lógica de comunicación que permite al usuario solicitar la generación de un PDF y recibirlo como una descarga en el navegador, completando el flujo principal de la aplicación.

#### **Cambios Implementados**

*   **Backend:** Se añadió la anotación `@CrossOrigin` al `PdfController` para permitir peticiones desde el servidor de desarrollo del frontend (`localhost:5173`), solucionando así los problemas de CORS.
*   **Frontend:** Se añadió un estado `isLoading` al componente `MarkdownEditor` para gestionar un indicador de carga visual.
*   **Frontend:** Se implementó la función `handleExportPdf` que se activa con el clic en el botón "Exportar a PDF".
*   **Frontend:** Dicha función realiza una petición `fetch` de tipo `POST` al endpoint `/api/generate-pdf`, enviando el contenido HTML del panel de previsualización.
*   **Frontend:** Se gestiona la respuesta del backend, la cual es un `blob` de tipo `application/pdf`.
*   **Frontend:** Se implementó la lógica para crear una URL temporal para el `blob` y simular un clic en un enlace para activar la descarga del archivo en el navegador del usuario.
*   **Frontend:** Se mejoró la UX deshabilitando el botón de exportación durante el proceso de generación del PDF y mostrando un texto de carga.